### PR TITLE
Add ActorCollections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'activesupport'
 gem 'celluloid'
+gem 'contracts'
 
 group :development, :test do
   gem 'pry', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,10 +28,12 @@ GEM
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     concurrent-ruby (1.0.2-java)
+    contracts (0.14.0)
     diff-lcs (1.2.5)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
     ffi (1.9.14)
+    ffi (1.9.14-java)
     formatador (0.2.5)
     guard (2.14.0)
       formatador (>= 0.2.4)
@@ -48,6 +50,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.4)
+    hitimes (1.2.4-java)
     i18n (0.7.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -122,6 +125,7 @@ DEPENDENCIES
   activesupport
   byebug
   celluloid
+  contracts
   factory_girl
   guard
   guard-rspec

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Run automatically and notify: `bundle exec guard`
 
 > This will communicate with you via the system notifications in OS X. This will let you stay in your editor full-time.
 
-Run a "full" simulation: `bundle exec ruby lib/medieval_game.rb`. 
+Run a "full" simulation: `time bundle exec ruby lib/medieval_game.rb`.
+Run a "full" simulation (w/o contract analysis): `time NO_CONTRACTS=true bundle exec ruby lib/medieval_game.rb`.
 
-> The full simulation is useful for playing around and to benchmark performance. 
+> The full simulation is useful for playing around and to benchmark performance.

--- a/config/festivals.yml
+++ b/config/festivals.yml
@@ -10,7 +10,9 @@
   # Death
   # Adventus (Monarch coming to town)
 
-calendar_to_use: "default"
+# Change this to alter which set of work_groups defined in this file to
+# load and use in the game.
+set_to_use: "default"
 
 weekly:
   sunday:

--- a/config/festivals.yml
+++ b/config/festivals.yml
@@ -10,7 +10,7 @@
   # Death
   # Adventus (Monarch coming to town)
 
-# Change this to alter which set of work_groups defined in this file to
+# Change this to alter which set of festivals defined in this file to
 # load and use in the game.
 set_to_use: "default"
 

--- a/config/work_groups.yml
+++ b/config/work_groups.yml
@@ -62,6 +62,10 @@
 #   percent_of_adults: 100 # percentage of population
 #   required_days: 27      # number of days spent
 
+# Change this to alter which set of work_groups defined in this file to
+# load and use in the game.
+set_to_use: "default"
+
 temp_ratios: &temp_ratios
   {}
 

--- a/config/work_groups.yml
+++ b/config/work_groups.yml
@@ -67,7 +67,10 @@
 set_to_use: "default"
 
 temp_ratios: &temp_ratios
-  {}
+  fixed_per_day:
+    max_adults: 2
+    min_adults: 2
+    person_days: 20
 
 default:
   # January & February - work indoors repairing hunting nets, sharpening tools,
@@ -134,8 +137,8 @@ default:
   february:
     spring_add_lime_chalk_and_manure: # improve bonus_fertility
       acres_per_day:
-        max_adults: .25 # 5 stout people over 4 days
-
+        per_adult: 1.0
+        min_adults: 1
 
     # prune_grapes:
     #   <<: *temp_ratios
@@ -304,6 +307,7 @@ default:
     # Church tithes - one sheaf in every ten - were collected from the field
     # before peasants carted their crop to their barns and houses.
     deliver_tithes: # reduce final_bushel_yield
+      <<: *temp_ratios
 
     # harvest_straw:
     #   <<: *temp_ratios
@@ -359,6 +363,7 @@ default:
     # Michaelmas (September 29), which marked the start of the new financial year
     # and was the day for settling debts, rents and dues."
     pay_taxes: # reduce final_grain_yield
+      <<: *temp_ratios
 
     # Crop            Seed (bu/acre)  Seed:Yield Ratio  Yield (bu/acre)
     # Wheat           2.8             3.8               10.5
@@ -375,6 +380,7 @@ default:
     # occured about one year in eight and good harvests (where the yields were
     # 15 per cent or more above the average) about one year in 20.
     calculate_final_grain_yield: # calculate final_grain_yield less taxes
+      <<: *temp_ratios
 
     # take_excess_stock_to_market:
     #   <<: *temp_ratios

--- a/config/work_orders.yml
+++ b/config/work_orders.yml
@@ -62,7 +62,7 @@
 #   percent_of_adults: 100 # percentage of population
 #   required_days: 27      # number of days spent
 
-# Change this to alter which set of work_groups defined in this file to
+# Change this to alter which set of work_orders defined in this file to
 # load and use in the game.
 set_to_use: "default"
 

--- a/lib/calendar.rb
+++ b/lib/calendar.rb
@@ -34,8 +34,8 @@ class Calendar
     end
 
     Contract nil => HashOf[String => HashOf[String => Hash]]
-    def months_work_groups
-      months_activities["work_groups"]
+    def months_work_orders
+      months_activities["work_orders"]
     end
 
     private
@@ -47,7 +47,7 @@ class Calendar
     def months_activities
       {
         "festivals"   => festivals[month_name] || {},
-        "work_groups" => work_groups[month_name] || {}
+        "work_orders" => work_orders[month_name] || {}
       }
     end
 
@@ -58,9 +58,9 @@ class Calendar
       end
     end
 
-    def work_groups
-      @work_groups ||= begin
-        yaml = yaml_load("work_groups")
+    def work_orders
+      @work_orders ||= begin
+        yaml = yaml_load("work_orders")
         yaml[yaml["set_to_use"]]
       end
     end

--- a/lib/calendar.rb
+++ b/lib/calendar.rb
@@ -65,8 +65,8 @@ class Calendar
       end
     end
 
-    def yaml_load(file)
-      File.open("config/#{file}.yml") { |file| YAML.load(file) }
+    def yaml_load(yaml_file)
+      File.open("config/#{yaml_file}.yml") { |file| YAML.load(file) }
     end
   end
 end

--- a/lib/calendar.rb
+++ b/lib/calendar.rb
@@ -46,12 +46,15 @@ class Calendar
     def festivals
       @festivals ||= begin
         yaml = yaml_load("festivals")
-        yaml[yaml["calendar_to_use"]]
+        yaml[yaml["set_to_use"]]
       end
     end
 
     def work_groups
-      @work_groups ||= yaml_load("work_groups")["default"]
+      @work_groups ||= begin
+        yaml = yaml_load("work_groups")
+        yaml[yaml["set_to_use"]]
+      end
     end
 
     def yaml_load(file)

--- a/lib/calendar.rb
+++ b/lib/calendar.rb
@@ -1,27 +1,41 @@
 require 'yaml'
 require 'active_support/core_ext/numeric/time'
+require 'contracts'
 
 class Calendar
+  include Contracts::Core
+  include Contracts::Builtin
+
   TICK_LENGTH = 1.hour
 
   class << self
+    Contract nil => DateTime
     def date
       @date ||= DateTime.new(800, 1, 1, 0, 0, 0, 0, Date::GREGORIAN)
     end
+
+    Contract DateTime => nil
     def date=(date)
       @date = date
+
+      return nil
     end
+
+    Contract nil => nil
     def tick
       Calendar.date += Calendar::TICK_LENGTH
 
       return nil
     end
 
-    def months_activities
-      {
-        "festivals"   => festivals[month_name] || {},
-        "work_groups" => work_groups[month_name] || {}
-      }
+    Contract nil => HashOf[Num => Hash["name" => String, "description" => String]]
+    def months_festivals
+      months_activities["festivals"]
+    end
+
+    Contract nil => HashOf[String => HashOf[String => Hash]]
+    def months_work_groups
+      months_activities["work_groups"]
     end
 
     private
@@ -30,17 +44,11 @@ class Calendar
       date.strftime("%B").downcase
     end
 
-    def season
-      case date.month
-      when 1..3
-        'winter'
-      when 4..6
-        'spring'
-      when 7..9
-        'summer'
-      when 10..12
-        'fall'
-      end
+    def months_activities
+      {
+        "festivals"   => festivals[month_name] || {},
+        "work_groups" => work_groups[month_name] || {}
+      }
     end
 
     def festivals

--- a/lib/citizen.rb
+++ b/lib/citizen.rb
@@ -6,7 +6,7 @@ require 'calendar'
 # Interface: Owner
 class Citizen
   attr_accessor :current_task
-  # attr_accessor :health, :wealth, :satisfaction, :age, :gender
+  attr_accessor :age, :health, :wealth, :satisfaction, :gender
   # attr_accessor :highest_rank, :titles
   # attr_accessor :parents, :spouse, :children
   # attr_accessor :pregnant_at
@@ -14,11 +14,11 @@ class Citizen
 
   attr_accessor :busy
 
-  def initialize(child: false)
+  def initialize(age: 0)
     # @health       = 100
     # @wealth       = 100
     # @satisfaction = 100
-    # @age          = 20
+    @age          = age
     # @gender       = 'male'
 
     # @highest_rank = 'serf'
@@ -37,16 +37,17 @@ class Citizen
     # @pregnant_at  = Time.now
     # @children     = []
 
-    @child        = child
-
     @stockpile    = Stockpile.new
     @fields       = [Field.new(acres: 10)]
 
     @busy = false
   end
 
+  def adult?
+    age >= 14
+  end
   def child?
-    !!@child
+    !adult?
   end
 
   def work

--- a/lib/citizen.rb
+++ b/lib/citizen.rb
@@ -2,6 +2,8 @@ require 'field'
 require 'stockpile'
 require 'calendar'
 
+# Interface: Actor
+# Interface: Owner
 class Citizen
   attr_accessor :current_task
   # attr_accessor :health, :wealth, :satisfaction, :age, :gender
@@ -45,6 +47,10 @@ class Citizen
 
   def child?
     !!@child
+  end
+
+  def work
+    # Do nothing
   end
 
   def sign_up

--- a/lib/family.rb
+++ b/lib/family.rb
@@ -1,7 +1,7 @@
 require 'contracts'
 require 'field'
 require 'stockpile'
-require 'work_group'
+require 'work_order'
 require 'citizen'
 
 # 266-381 days worked per year per family

--- a/lib/family.rb
+++ b/lib/family.rb
@@ -17,27 +17,30 @@ class Family
   include Contracts::Builtin
 
   attr_reader :stockpile
-  attr_reader :children
   attr_accessor :fields
 
-  def initialize(head:, next_in_line:, children:)
+  def initialize(head:, next_in_line:, members:)
     @name = ""
 
     @head_of_family = head
     @next_in_line = next_in_line
-    @children = children || []
+    @members = members || []
 
     @stockpile    = Stockpile.new
     @fields       = []
   end
 
   def adults
-    [@head, @next_in_line].compact
+    @adults ||= members.select {|member| member.adult? }.compact
+  end
+  def children
+    # FIXME: This will not update when the child turns 14
+    @children ||= members.select {|member| member.child? }.compact
   end
 
   Contract nil => ArrayOf[Citizen]
-  def all
-    (adults + children).compact.flatten
+  def members
+    @members
   end
 
   Contract nil => Num
@@ -46,7 +49,7 @@ class Family
   end
 
   def work
-    all.map(&:work)
+    members.map(&:work)
   end
 
   Contract nil => ArrayOf[WorkOrder]

--- a/lib/family.rb
+++ b/lib/family.rb
@@ -1,4 +1,6 @@
 require 'contracts'
+require 'celluloid/current'
+
 require 'field'
 require 'stockpile'
 require 'work_order'
@@ -6,6 +8,8 @@ require 'citizen'
 
 # 266-381 days worked per year per family
 # 1.13-3.4 d. per day.
+#
+# Interface: ActorCollection
 class Family
   include Celluloid::Internals::Logger
 
@@ -13,6 +17,7 @@ class Family
   include Contracts::Builtin
 
   attr_reader :stockpile
+  attr_reader :children
   attr_accessor :fields
 
   def initialize(head:, next_in_line:, children:)
@@ -26,13 +31,56 @@ class Family
     @fields       = []
   end
 
-  attr_reader :children
   def adults
-    [@head, @next_in_line]
+    [@head, @next_in_line].compact
+  end
+
+  Contract nil => ArrayOf[Citizen]
+  def all
+    (adults + children).compact.flatten
   end
 
   Contract nil => Num
   def acreage # Total for Weisbach was 45d/acre
     fields.map(&:acreage).reduce(:+)
+  end
+
+  def work
+    all.map(&:work)
+  end
+
+  Contract nil => ArrayOf[WorkOrder]
+  def advertise
+    wg = []
+
+    Calendar.months_work_orders.each do |name, needs|
+      type = needs.keys.first
+      values = needs.values.first
+
+      # info "name: #{name}, type: #{type} values: #{values}"
+
+      case type
+      when "fixed_per_day"
+        wg << WorkOrder.new(
+          name: name,
+          min_adults: values["min_adults"],
+          max_adults: values["max_adults"],
+          min_children: values["min_children"],
+          max_children: values["max_children"],
+          person_days: values["person_days"]
+        )
+      when "acres_per_day"
+        fields.each do |field|
+          wg << WorkOrder.new(
+            name: "#{name} #{field.object_id}",
+            min_adults: values["min_adults"] || 0,
+            max_adults: field.acreage.fdiv(values['per_adult']),
+            person_days: field.acreage.fdiv(values['per_adult'])
+          )
+        end
+      end
+    end
+
+    return wg
   end
 end

--- a/lib/family.rb
+++ b/lib/family.rb
@@ -1,9 +1,17 @@
+require 'contracts'
 require 'field'
 require 'stockpile'
+require 'work_group'
+require 'citizen'
 
 # 266-381 days worked per year per family
 # 1.13-3.4 d. per day.
 class Family
+  include Celluloid::Internals::Logger
+
+  include Contracts::Core
+  include Contracts::Builtin
+
   attr_reader :stockpile
   attr_accessor :fields
 
@@ -23,6 +31,7 @@ class Family
     [@head, @next_in_line]
   end
 
+  Contract nil => Num
   def acreage # Total for Weisbach was 45d/acre
     fields.map(&:acreage).reduce(:+)
   end

--- a/lib/field.rb
+++ b/lib/field.rb
@@ -4,10 +4,10 @@ class Field
   attr_accessor :sown_with, :percent_sown, :percent_grown
 
   def initialize(acres:)
-    @acreage  = acres || 10
+    @acreage       = acres || 10
     @bonus_fertile = 0
-    @bonus_yield = 0
-    @percent_sown = 0
+    @bonus_yield   = 0
+    @percent_sown  = 0
     @percent_grown = 0
   end
 

--- a/lib/medieval_game.rb
+++ b/lib/medieval_game.rb
@@ -53,11 +53,11 @@ if $PROGRAM_NAME == __FILE__
           village.families << Family.new(
             head: Citizen.new,
             next_in_line: Citizen.new,
-            children: [
-              Citizen.new(child: true),
-              Citizen.new(child: true),
-              Citizen.new(child: true),
-              Citizen.new(child: true)]
+            members: [
+              Citizen.new(age: 13),
+              Citizen.new(age: 13),
+              Citizen.new(age: 13),
+              Citizen.new(age: 13)]
           )
         end
       end

--- a/lib/medieval_game.rb
+++ b/lib/medieval_game.rb
@@ -62,10 +62,11 @@ if $PROGRAM_NAME == __FILE__
         end
       end
     end
-    results.report("one year:") do
-      number_of_ticks.times do
-        print '.'
-        game.tick
+    1.upto(52) do |i|
+      results.report("week #{i}:") do
+        (1.week / Calendar::TICK_LENGTH).times do
+          game.tick
+        end
       end
     end
   end

--- a/lib/village.rb
+++ b/lib/village.rb
@@ -43,6 +43,7 @@ class Village < Site
 
   def tick
     if Calendar.date.mday == 1 && Calendar.date.hour == 1
+      # FIXME: We should probably simplify to just doing days
       # FIXME: This may be deleting tasks that still need to be done
       # TODO: Implement max amount of time to try a thing. Like, we
       # could only plant so much this year, so that sucks.
@@ -61,10 +62,7 @@ class Village < Site
   end
 
   def citizens
-    citizens = families.map do |family|
-      [family.adults, family.children]
-    end
-    citizens.flatten.compact
+    citizens = families.map(&:members).flatten.compact
   end
 
   def fields

--- a/lib/work_group.rb
+++ b/lib/work_group.rb
@@ -1,71 +1,16 @@
+# Interface: ActorCollection
 class WorkGroup
   attr_reader :name
-  attr_accessor :children, :adults, :completeness
 
-  def initialize(name:, max_adults: 0, max_children: 0, person_days:)
-    @name         = name
-    @max_adults   = max_adults || 0
-    @max_children = max_children || 0
-    @person_days  = person_days
-    @completeness = 0
-    @adults       = 0
-    @children     = 0
+  def initialize(name:)
+    @adults       = []
+    @children     = []
   end
 
-  def finished?
-    completeness >= 100
-  end
-
-  def full?
-    adults == max_adults && children == max_children
-  end
-
-  def sign_up(child: false)
-    if child == true && children < max_children
-      self.children += 1
-      return true
-    elsif child == false && adults < max_adults
-      self.adults += 1
-      return true
-    else
-      return false
-    end
-  end
-
-  def empty
-    self.adults = 0
-    self.children = 0
-  end
-
-  def progress
-    self.completeness += worker_count.fdiv(person_days) * 100
-
-    # if finished?
-    #   info "DONE! #{name}"
-    # else
-    #   info "Progress: #{completeness} #{name}"
-    # end
-
-    return nil
-  end
-
-  def to_s
-    "#{name}: fullness - #{fullness}, progress - #{completeness}"
-  end
-
-  def fullness
-    (adults + children).fdiv(max_workers)
-  end
-
-  def max_workers
-    max_adults + max_children
-  end
-
-  def worker_count
-    adults + children
-  end
-
-  private
-
-  attr_reader :needs, :max_adults, :max_children, :person_days, :type
+  def work; end
+  def advertise; end
+  def join; end
+  def leave; end
+  def empty; end
+  def worker_count; end
 end

--- a/lib/work_order.rb
+++ b/lib/work_order.rb
@@ -1,0 +1,71 @@
+class WorkOrder
+  attr_reader :name
+  attr_accessor :completeness, :adults, :children
+
+  def initialize(name:, min_adults: 0, max_adults: 0, min_children: 0, max_children: 0, person_days:)
+    @name         = name
+    @max_adults   = max_adults || 0
+    @max_children = max_children || 0
+    @person_days  = person_days
+    @completeness = 0
+    @adults       = 0
+    @children     = 0
+  end
+
+  def finished?
+    completeness >= 100
+  end
+
+  def full?
+    adults == max_adults && children == max_children
+  end
+
+  def sign_up(child: false)
+    if child == true && children < max_children
+      self.children += 1
+      return true
+    elsif child == false && adults < max_adults
+      self.adults += 1
+      return true
+    else
+      return false
+    end
+  end
+
+  def empty
+    self.adults = 0
+    self.children = 0
+  end
+
+  def progress
+    self.completeness += worker_count.fdiv(person_days) * 100
+
+    # if finished?
+    #   info "DONE! #{name}"
+    # else
+    #   info "Progress: #{completeness} #{name}"
+    # end
+
+    return nil
+  end
+
+  def to_s
+    "#{name}: fullness - #{fullness}, progress - #{completeness}"
+  end
+
+  def fullness
+    (adults + children).fdiv(max_workers)
+  end
+
+  def max_workers
+    max_adults + max_children
+  end
+
+  def worker_count
+    adults + children
+  end
+
+  private
+
+  attr_reader :needs, :max_adults, :max_children, :person_days, :type
+end

--- a/spec/integration/medieval_game_integration_spec.rb
+++ b/spec/integration/medieval_game_integration_spec.rb
@@ -20,11 +20,11 @@ describe MedievalGame do
         family = Family.new(
           head: Citizen.new,
           next_in_line: Citizen.new,
-          children: [
-            Citizen.new(child: true),
-            Citizen.new(child: true),
-            Citizen.new(child: true),
-            Citizen.new(child: true)]
+          members: [
+            Citizen.new(age: 14),
+            Citizen.new(age: 14),
+            Citizen.new(age: 14),
+            Citizen.new(age: 14)]
         )
         family.fields = [
           Field.new(acres: 7),

--- a/spec/lib/calendar_spec.rb
+++ b/spec/lib/calendar_spec.rb
@@ -6,30 +6,15 @@ describe Calendar do
     Calendar.date = DateTime.new(800, 1, 1, 0, 0, 0, 0, Date::GREGORIAN)
   end
 
-  it 'understands the seasons' do
-    described_class.date = DateTime.new(800, 1, 1, 0, 0, 0, 0, Date::GREGORIAN)
-    expect(described_class.send(:season)).to eq('winter')
-
-    described_class.date = DateTime.new(800, 4, 1, 0, 0, 0, 0, Date::GREGORIAN)
-    expect(described_class.send(:season)).to eq('spring')
-
-    described_class.date = DateTime.new(800, 7, 1, 0, 0, 0, 0, Date::GREGORIAN)
-    expect(described_class.send(:season)).to eq('summer')
-
-    described_class.date = DateTime.new(800, 10, 1, 0, 0, 0, 0, Date::GREGORIAN)
-    expect(described_class.send(:season)).to eq('fall')
-  end
-
   describe 'activities for the month' do
     it 'finds february\'s activities' do
       described_class.date = DateTime.new(800, 2, 1, 0, 0, 0, 0, Date::GREGORIAN)
 
-      activities = described_class.months_activities
-      expect(activities).to have_key("work_groups")
-      expect(activities["work_groups"]).to include('spring_add_lime_chalk_and_manure')
+      activities = described_class.months_work_groups
+      expect(activities).to include('spring_add_lime_chalk_and_manure')
 
-      expect(activities).to have_key("festivals")
-      expect(activities["festivals"][14]["name"]).to include('Fertility')
+      activities = described_class.months_festivals
+      expect(activities[14]["name"]).to include('Fertility')
     end
   end
 end

--- a/spec/lib/calendar_spec.rb
+++ b/spec/lib/calendar_spec.rb
@@ -10,7 +10,7 @@ describe Calendar do
     it 'finds february\'s activities' do
       described_class.date = DateTime.new(800, 2, 1, 0, 0, 0, 0, Date::GREGORIAN)
 
-      activities = described_class.months_work_groups
+      activities = described_class.months_work_orders
       expect(activities).to include('spring_add_lime_chalk_and_manure')
 
       activities = described_class.months_festivals

--- a/spec/lib/citizen_spec.rb
+++ b/spec/lib/citizen_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 require 'citizen'
 require 'actor_examples'
+require 'owner_examples'
 
 describe Citizen do
   it_behaves_like 'actor'
+  it_behaves_like 'owner'
 
   subject { described_class.new }
 

--- a/spec/lib/citizen_spec.rb
+++ b/spec/lib/citizen_spec.rb
@@ -9,7 +9,15 @@ describe Citizen do
 
   subject { described_class.new }
 
-  it 'does something' do
-    subject
+  describe 'children' do
+    it "is a child if under 14 years old" do
+      allow(subject).to receive(:age).and_return 13
+      expect(subject.child?).to be true
+    end
+    it "is an adult if 14 years old or older" do
+      allow(subject).to receive(:age).and_return 14
+      expect(subject.child?).to be false
+    end
+
   end
 end

--- a/spec/lib/citizen_spec.rb
+++ b/spec/lib/citizen_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 require 'citizen'
+require 'actor_examples'
 
 describe Citizen do
+  it_behaves_like 'actor'
+
   subject { described_class.new }
 
   it 'does something' do

--- a/spec/lib/family_spec.rb
+++ b/spec/lib/family_spec.rb
@@ -11,7 +11,7 @@ describe Family do
     described_class.new(
       head: instance_double("Citizen", :work => true),
       next_in_line: instance_double("Citizen", :work => true),
-      children: [instance_double("Citizen", :child? => true, :work => true)]
+      members: [instance_double("Citizen", :child? => true, :work => true)]
     )
   }
 

--- a/spec/lib/family_spec.rb
+++ b/spec/lib/family_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 require 'family'
 require 'actor_collection_examples'
+require 'owner_examples'
 
 describe Family do
   it_behaves_like 'actor_collection'
+  it_behaves_like 'owner'
 
   subject {
     described_class.new(
-      head: instance_double("Citizen"),
-      next_in_line: instance_double("Citizen"),
-      children: [instance_double("Citizen", :child? => true)]
+      head: instance_double("Citizen", :work => true),
+      next_in_line: instance_double("Citizen", :work => true),
+      children: [instance_double("Citizen", :child? => true, :work => true)]
     )
   }
 

--- a/spec/lib/family_spec.rb
+++ b/spec/lib/family_spec.rb
@@ -1,6 +1,10 @@
+require 'spec_helper'
 require 'family'
+require 'actor_collection_examples'
 
 describe Family do
+  it_behaves_like 'actor_collection'
+
   subject {
     described_class.new(
       head: instance_double("Citizen"),

--- a/spec/lib/village_spec.rb
+++ b/spec/lib/village_spec.rb
@@ -11,7 +11,7 @@ describe Village do
 
   describe '#reset_work_orders' do
     before :each do
-      allow(subject.wrapped_object).to receive(:generate_work_groups)
+      allow(subject.wrapped_object).to receive(:advertise)
     end
 
     it 'resets on the first of the month' do
@@ -34,9 +34,9 @@ describe Village do
     it 'orchestrates work during working hours' do
       Calendar.date = DateTime.new(800, 1, 1, 6, 0, 0, 0, Date::GREGORIAN)
 
-      expect(subject.wrapped_object).to receive(:generate_work_groups)
-      expect(subject.wrapped_object).to receive(:assign_citizens_to_work_groups)
-      expect(subject.wrapped_object).to receive(:get_shit_done)
+      expect(subject.wrapped_object).to receive(:advertise)
+      expect(subject.wrapped_object).to receive(:assign_citizens_to_work_orders)
+      expect(subject.wrapped_object).to receive(:work)
       subject.tick
     end
 

--- a/spec/lib/village_spec.rb
+++ b/spec/lib/village_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 require 'village'
+require 'actor_collection_examples'
 
 describe Village do
+  it_behaves_like 'actor_collection'
+
   after :each do
     Calendar.date = DateTime.new(800, 1, 1, 0, 0, 0, 0, Date::GREGORIAN)
   end

--- a/spec/lib/village_spec.rb
+++ b/spec/lib/village_spec.rb
@@ -9,7 +9,7 @@ describe Village do
     Calendar.date = DateTime.new(800, 1, 1, 0, 0, 0, 0, Date::GREGORIAN)
   end
 
-  describe '#reset_work_groups' do
+  describe '#reset_work_orders' do
     before :each do
       allow(subject.wrapped_object).to receive(:generate_work_groups)
     end
@@ -17,9 +17,9 @@ describe Village do
     it 'resets on the first of the month' do
       Calendar.date = DateTime.new(800, 1, 1, 1, 0, 0, 0, Date::GREGORIAN)
 
-      subject.work_groups = [instance_double("WorkGroup", :finished? => true)]
-      subject.send(:reset_work_groups)
-      expect(subject.work_groups).to eq([])
+      subject.work_orders = [instance_double("WorkOrder", :finished? => true)]
+      subject.send(:reset_work_orders)
+      expect(subject.work_orders).to eq([])
     end
   end
 
@@ -27,7 +27,7 @@ describe Village do
     it 'resets in the first hour of the month' do
       Calendar.date = DateTime.new(800, 1, 1, 1, 0, 0, 0, Date::GREGORIAN)
 
-      expect(subject.wrapped_object).to receive(:reset_work_groups)
+      expect(subject.wrapped_object).to receive(:reset_work_orders)
       subject.tick
     end
 

--- a/spec/lib/work_group.rb
+++ b/spec/lib/work_group.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+require 'work_order'
+require 'actor_collection_examples'
+
+describe WorkGroup do
+  it_behaves_like 'actor_collection'
+end

--- a/spec/lib/work_group_spec.rb
+++ b/spec/lib/work_group_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 require 'work_group'
+require 'actor_collection_examples'
 
 describe WorkGroup do
+  it_behaves_like 'actor_collection'
+
   subject {
     described_class.new(
       name: "test",

--- a/spec/lib/work_order_spec.rb
+++ b/spec/lib/work_order_spec.rb
@@ -1,10 +1,7 @@
 require 'spec_helper'
-require 'work_group'
-require 'actor_collection_examples'
+require 'work_order'
 
-describe WorkGroup do
-  it_behaves_like 'actor_collection'
-
+describe WorkOrder do
   subject {
     described_class.new(
       name: "test",
@@ -13,7 +10,6 @@ describe WorkGroup do
       person_days: 40
     )
   }
-  let(:village) { instance_double("Village") }
 
   describe 'full work group' do
     before :each do
@@ -27,7 +23,7 @@ describe WorkGroup do
       expect(subject.full?).to be true
     end
 
-    it 'progresses' do
+    it 'progress' do
       expect(subject.completeness).to eq(0)
       subject.progress
       expect(subject.completeness).to eq(10)
@@ -40,7 +36,7 @@ describe WorkGroup do
     end
   end
 
-  describe 'half-full work group' do
+  describe 'half-full progress group' do
     before :each do
       subject.sign_up
       subject.sign_up(child: true)
@@ -50,7 +46,7 @@ describe WorkGroup do
       expect(subject.full?).to be false
     end
 
-    it 'progresses' do
+    it 'progress' do
       expect(subject.completeness).to eq(0)
       subject.progress
       expect(subject.completeness).to eq(5)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'support'))
 
 require 'rspec'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'support'))
 
 require 'rspec'
+require 'contracts'
 
 RSpec.configure do |rspec|
   rspec.after :each do
@@ -12,5 +13,14 @@ RSpec.configure do |rspec|
     # end
     require 'calendar'
     expect(Calendar.date).to eq(DateTime.new(800, 1, 1, 0, 0, 0, 0, Date::GREGORIAN))
+  end
+
+  # Make contracts accept all RSpec doubles
+  Contract.override_validator(:class) do |contract|
+    lambda do |arg|
+      arg.is_a?(RSpec::Mocks::Double) ||
+        arg.is_a?(RSpec::Mocks::InstanceVerifyingDouble) ||
+        arg.is_a?(contract)
+    end
   end
 end

--- a/spec/support/actor_collection_examples.rb
+++ b/spec/support/actor_collection_examples.rb
@@ -1,13 +1,19 @@
 RSpec.shared_examples 'actor_collection' do
   describe '#work' do
-    xit 'should be implemented' do
+    it 'should be implemented' do
       expect { subject.work }.to_not raise_error
     end
   end
 
-  describe '#advertise' do
+  describe '#join' do
     xit 'should be implemented' do
-      expect { subject.advertise }.to_not raise_error
+      expect { subject.join }.to_not raise_error
+    end
+  end
+
+  describe '#leave' do
+    xit 'should be implemented' do
+      expect { subject.leave }.to_not raise_error
     end
   end
 

--- a/spec/support/actor_collection_examples.rb
+++ b/spec/support/actor_collection_examples.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'actor_collection' do
+  describe '#work' do
+    xit 'should be implemented' do
+      expect { subject.work }.to_not raise_error
+    end
+  end
+
+  describe '#advertise' do
+    xit 'should be implemented' do
+      expect { subject.advertise }.to_not raise_error
+    end
+  end
+
+  describe '#current_ai' do
+    xit 'should be implemented' do
+      expect { subject.current_ai }.to_not raise_error
+    end
+  end
+
+  describe '#values' do
+    xit 'should be implemented' do
+      expect { subject.values }.to_not raise_error
+    end
+  end
+end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'actor' do
   describe '#work' do
-    xit 'should be implemented' do
+    it 'should be implemented' do
       expect { subject.work }.to_not raise_error
     end
   end

--- a/spec/support/actor_examples.rb
+++ b/spec/support/actor_examples.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'actor' do
+  describe '#work' do
+    xit 'should be implemented' do
+      expect { subject.work }.to_not raise_error
+    end
+  end
+
+  describe '#advertise' do
+    xit 'should be implemented' do
+      expect { subject.advertise }.to_not raise_error
+    end
+  end
+
+  describe '#current_ai' do
+    xit 'should be implemented' do
+      expect { subject.current_ai }.to_not raise_error
+    end
+  end
+
+  describe '#values' do
+    xit 'should be implemented' do
+      expect { subject.values }.to_not raise_error
+    end
+  end
+end

--- a/spec/support/owner_examples.rb
+++ b/spec/support/owner_examples.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'owner' do
+  describe '#advertise' do
+    xit 'should be implemented' do
+      expect { subject.fields }.to_not raise_error
+    end
+  end
+
+  describe '#fields' do
+    it 'should be implemented' do
+      expect { subject.fields }.to_not raise_error
+    end
+  end
+
+  describe '#stockpile' do
+    it 'should be implemented' do
+      expect { subject.stockpile }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Trying to get to the place where we can have a collection of citizens that acts the same regardless of size. So each one will have a `work` and `travel` method, but they might be no-ops. But I've not yet figured out what the collections actually _do_ yet, so it's a bit in flux.
- Add in ruby Contract analysis
- Also, add in some rspec shared_examples to inform the multiple types of... citizen collections? 
- Total rethink of how work_orders.yml (nee work_groups.yml) actually works and the math behind it. Now it'll be much more consistent, it'll come down to `min/max_workers` and `person_days`.
